### PR TITLE
Update lookup.js

### DIFF
--- a/resources/js/lookup.js
+++ b/resources/js/lookup.js
@@ -8,6 +8,10 @@ $(function () {
         var wrapper = input.closest('.form-group');
         var modal = $('#' + field + '-modal');
 
+        if (!$('[name="' + field + '"]').length) {
+            return;
+        }
+        
         var selected = $('[name="' + field + '"]').val().split(',');
 
         modal.on('click', '[data-entry]', function (e) {


### PR DESCRIPTION
Blows up when you have both a lookup and tag based multiple relation field on the same form as a tag based lookup.  For example put a multiple relationship of type "lookup" in the user form.  Line 11 blows up as there is no input by that name.  This issue likely affects other areas.  I put this fix into beta2 as a workaround but i'm sure the issue likely happens in beta3 as well.
