### PR TITLE
Patch "Undefined variable $input-bg: line: 12"

### DIFF
--- a/resources/scss/choices.scss
+++ b/resources/scss/choices.scss
@@ -9,7 +9,7 @@ $choices-font-size-sm: 12px !default;
 $choices-guttering: 0.5rem !default;
 $choices-border-radius: .1rem !default;
 $choices-border-radius-item: .1rem !default;
-$choices-bg-color: $input-bg !default;
+$choices-bg-color: #fff !default;
 $choices-bg-color-disabled: #eceeef !default;
 $choices-bg-color-dropdown: #FFFFFF !default;
 $choices-text-color: #55595c !default;


### PR DESCRIPTION
Including this CSS into a frontend throws `Undefined variable $input-bg: line: 12`. This is because `$input-bg` is defined in the Accelerant Theme `theme.scss` file and therefore is undefined in the frontend.

I believe this issue is present in multiple other add-ons as well:
- addon-field_type
- checkboxes-field_type
- country-field_type
- language-field_type
- multiple-field_type
- select-field_type
- state-field_type
- tags-field_type

It's definitely nice that it's set up so that the accelerant theme can define that one variable and have it pull through to all the add-ons. It is a little impractical for frontend theming where SCSS might not even be compiled live.

I'm happy to do a bunch of pull requests if this is change that we are interested in.