### PR TITLE
Add `|raw` to translations to function correctly

### DIFF
--- a/resources/views/checkboxes.twig
+++ b/resources/views/checkboxes.twig
@@ -17,7 +17,7 @@
                                 {{ key in field_type.config.checked ? 'checked' }}
                                 {{ key in field_type.ids ? 'checked' }}>
 
-                        {{ trans(title) }}
+                        {{ trans(title)|raw }}
                     </label>
                 {% endfor %}
             </p>
@@ -32,7 +32,7 @@
                         {{ key in field_type.config.checked ? 'checked' }}
                         {{ key in field_type.ids ? 'checked' }}>
 
-                {{ trans(title) }}
+                {{ trans(title)|raw }}
             </label>
         {% endif %}
 


### PR DESCRIPTION
Add `|raw` to translations to function correctly