### PR TITLE
Use minified as non min throws errors

### DIFF
--- a/resources/views/tags.twig
+++ b/resources/views/tags.twig
@@ -1,5 +1,5 @@
 {{ asset_add("styles.css", "anomaly.field_type.multiple::css/choices.css", ["as:jshjohnson/Choices.css"]) }}
-{{ asset_add("scripts.js", "anomaly.field_type.multiple::js/choices.js", ["as:jshjohnson/Choices.js"]) }}
+{{ asset_add("scripts.js", "anomaly.field_type.multiple::js/choices.min.js", ["as:jshjohnson/Choices.js"]) }}
 {{ asset_add("styles.css", "anomaly.field_type.multiple::css/tags.css") }}
 {{ asset_add("scripts.js", "anomaly.field_type.multiple::js/tags.js") }}
 


### PR DESCRIPTION
The non minified file doesn't define `module` so throws errors, using the min file works fine.